### PR TITLE
Сhange font from didot to PTSans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,6 +1681,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@openfonts/pt-sans_cyrillic": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@openfonts/pt-sans_cyrillic/-/pt-sans_cyrillic-1.44.0.tgz",
+      "integrity": "sha512-LY/y80Tlwq38mYpQ+ZkEYaoK3W41fEqqp/l9Vu2ZxrVw6+jTdFtASXoSGuKPNYa2Y0wRzYHudqhtfnuuTcfVpw=="
+    },
     "@pieh/friendly-errors-webpack-plugin": {
       "version": "1.7.0-chalk-2",
       "resolved": "https://registry.npmjs.org/@pieh/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0-chalk-2.tgz",
@@ -19375,11 +19380,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typeface-gfs-didot": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/typeface-gfs-didot/-/typeface-gfs-didot-0.0.72.tgz",
-      "integrity": "sha512-gRuy3XmeGOf5mSnhVjouuyr4y2WaN/NoSlQOALcxOGvRE2Hu/2RW3q4osdPVFuS1WsOicCESX7ixs6if7rZ7WA=="
     },
     "typescript": {
       "version": "3.7.5",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@material-ui/core": "^4.9.3",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/styles": "^4.9.0",
+    "@openfonts/pt-sans_cyrillic": "^1.44.0",
     "babel-plugin-styled-components": "^1.10.7",
     "gatsby": "^2.19.18",
     "gatsby-image": "^2.0.23",
@@ -37,7 +38,6 @@
     "react-id-swiper": "^2.4.0",
     "react-vertical-timeline-component": "^2.5.0",
     "swiper": "^5.3.1",
-    "typeface-gfs-didot": "0.0.72",
     "uuid": "^3.2.1"
   },
   "keywords": [

--- a/static/themes/theme.ts
+++ b/static/themes/theme.ts
@@ -1,9 +1,9 @@
 // https://medium.com/javascript-in-plain-english/extend-material-ui-theme-in-typescript-a462e207131f - my instruction
 import { createMuiTheme, responsiveFontSizes } from '@material-ui/core/styles';
-import 'typeface-gfs-didot';
+import '@openfonts/pt-sans_cyrillic';
 
-const didot = {
-  fontFamily: 'GFS Didot, serif',
+const ptSans = {
+  fontFamily: 'PT Sans, serif',
   fontStyle: 'normal',
   fontWeight: '400',
 };
@@ -28,7 +28,7 @@ const theme = createMuiTheme({
     },
   },
   typography: {
-    fontFamily: 'GFS Didot',
+    fontFamily: 'PT Sans',
     fontSize: 16,
     h1: {
       fontSize: '2.25rem',
@@ -78,7 +78,7 @@ const theme = createMuiTheme({
   overrides: {
     MuiCssBaseline: {
       '@global': {
-        '@font-face': [didot],
+        '@font-face': [ptSans],
       },
     },
   },


### PR DESCRIPTION
Сhange font from didot to PTSans:
- deleted old didot font with typeface-gfs-didot package
- installed @openfonts/pt-sans_cyrillic
- changed font in themes/theme.ts